### PR TITLE
Fix include name

### DIFF
--- a/include/TrackInitialization.h
+++ b/include/TrackInitialization.h
@@ -3,7 +3,7 @@
 #include "LRFSensor.h"
 #include "PolygonalRegion.h"
 #include "ColorCout.h"
-#include "MOtracker.h"
+#include "MOTracker.h"
 class CTrackInitialization
 {
 public:


### PR DESCRIPTION
インクルードファイルのスペルミスを修正しました．
他はドキュメント通りに進めるだけでビルドできることを確認しています．

実行環境：Ubuntu 14.04 LTS / ROS Indigo
